### PR TITLE
Fix: Treatment Doctype

### DIFF
--- a/farm_management/farm_management/doctype/treatment/treatment.js
+++ b/farm_management/farm_management/doctype/treatment/treatment.js
@@ -1,8 +1,47 @@
 // Copyright (c) 2025, Group 2 and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Treatment", {
-// 	refresh(frm) {
+frappe.ui.form.on("Treatment", {
+    refresh(frm) {
+        frm.toggle_enable("product_details", frm.doc.warehouse);
 
-// 	},
-// });
+        // Only list warehouses that have products in stock.
+        frappe.db.get_list("Bin", {
+            fields: ["warehouse", "actual_qty"],
+        }).then(bins => {
+            bins = bins.filter(i => i.actual_qty > 0)
+            bins = [...new Set(bins.map(i => i.warehouse))]
+
+            frm.set_query("warehouse", () => {
+                return {
+                    filters: {
+                        "name": ["in", bins]
+                    }
+                }
+            })
+
+        })
+
+    },
+    warehouse(frm) {
+        frm.toggle_enable("product_details", frm.doc.warehouse);
+        frm.set_value("product_details", "")
+
+        // Filter items only in the specified warehouse.
+        frappe.db.get_list("Bin", {
+            fields: ["item_code"],
+            filters: {
+                warehouse: frm.doc.warehouse,
+                actual_qty: [">", 0]
+            }
+        }).then(bins => {
+            frm.set_query("product_details", () => {
+                return {
+                    filters: {
+                        "item_name": ["in", bins.map(i => i.item_code)]
+                    }
+                }
+            })
+        })
+    },
+});

--- a/farm_management/farm_management/doctype/treatment/treatment.json
+++ b/farm_management/farm_management/doctype/treatment/treatment.json
@@ -35,7 +35,8 @@
    "fieldname": "warehouse",
    "fieldtype": "Link",
    "label": "Warehouse",
-   "options": "Warehouse"
+   "options": "Warehouse",
+   "reqd": 1
   },
   {
    "fieldname": "treatment_type",
@@ -47,12 +48,14 @@
    "fieldname": "product_details",
    "fieldtype": "Link",
    "label": "Product",
-   "options": "Item"
+   "options": "Item",
+   "reqd": 1
   },
   {
    "fieldname": "quantity",
    "fieldtype": "Float",
-   "label": "Quantity"
+   "label": "Quantity",
+   "reqd": 1
   },
   {
    "fieldname": "uom",
@@ -134,7 +137,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-26 17:13:51.891681",
+ "modified": "2025-04-29 13:14:10.657905",
  "modified_by": "Administrator",
  "module": "Farm Management",
  "name": "Treatment",
@@ -154,6 +157,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Javascript
- Added script filter only warehouses with available stock and filter out all warehouses option.
- Added script to make product read only if warehouse not selected.
- Added script to filter only products in the selected warehouse.
## Python
- Added script to check if the selected quantity is higher than available stock, and throw an error.